### PR TITLE
transfer base to read.450k from read.450k.exp with targets

### DIFF
--- a/R/read.450k.R
+++ b/R/read.450k.R
@@ -125,7 +125,7 @@ read.450k.exp <- function(base, targets = NULL, extended = FALSE,
     if(!is.null(targets)) {
         if(! "Basename" %in% names(targets))
             stop("Need 'Basename' amongst the column names of 'targets'")
-        files <- targets$Basename
+        files <- paste0(base, targets$Basename)
         rgSet <- read.450k(files, extended = extended, verbose = verbose)
         pD <- targets
         pD$filenames <- files


### PR DESCRIPTION
currently, if we send in a targets dataframe to read.450k.exp and base is anything but "", then it does not get passed correctly to read.450k
this addresses that.
