### PR TITLE
Cpgcollapse genomicratioset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: minfi
-Version: 1.13.8
+Version: 1.13.9
 Title: Analyze Illumina's 450k methylation arrays
 Description: Tools for analyzing and visualizing Illumina's 450k array data.
 Authors@R: c(person(c("Kasper", "Daniel"), "Hansen", role = c("cre", "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Analyze Illumina's 450k methylation arrays
 Description: Tools for analyzing and visualizing Illumina's 450k array data.
 Authors@R: c(person(c("Kasper", "Daniel"), "Hansen", role = c("cre", "aut"),
                     email = "kasperdanielhansen@gmail.com"),
-             person("Martin", "Ayree", role = "aut"),
+             person("Martin", "Aryee", role = "aut"),
              person(c("Rafael", "A."), "Irizarry", role = "aut"),
 	     person(c("Andrew", "E."), "Jaffe", role = "ctb"),
 	     person("Jovana", "Maksimovic", role = "ctb"),

--- a/R/blocks.R
+++ b/R/blocks.R
@@ -72,21 +72,26 @@ cpgCollapse <- function(object, what = c("Beta", "M"), maxGap = 500,
     a <- getCN(object,...)
     
     if(verbose) cat("[cpgCollapse] Collapsing data")
-    
     Indexes <- split(seq(along = anno$pns), anno$pns)
     yy  <- matrix(0, length(Indexes), ncol(y))
-    aa  <- matrix(0,length(Indexes), ncol(y))
     Ns <- sapply(Indexes, length)
     ones <- (Ns == 1)
     ind <- which(ones)
     yy[ind,] <- y[unlist(Indexes[ind]),]
-    aa[ind,] <- a[unlist(Indexes[ind]),]
+    if (class(object)=="GenomicMethylSet") {
+      aa  <- matrix(0,length(Indexes), ncol(y))
+      aa[ind,] <- a[unlist(Indexes[ind]),]
+    } else {
+      aa <- NULL
+    }
 
     ind <- which(!ones)
     for(i in ind) {
         if(verbose) if(runif(1) < 0.0001) cat(".")
         yy[i,] <- dataSummary(y[Indexes[[i]],, drop=FALSE], na.rm = na.rm)
-        aa[i,] <- dataSummary(a[Indexes[[i]],, drop=FALSE], na.rm = na.rm)
+        if (class(object)=="GenomicMethylSet") {
+          aa[i,] <- dataSummary(a[Indexes[[i]],, drop=FALSE], na.rm = na.rm)
+        }
     }
     if(verbose) cat("\n")
     

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -32,7 +32,9 @@
     in files in the TCGA format. The function is very specific to this
     format.
     \item Minor coding fixes including some NAMESPACE issues, missing
-    pData<- methods, replace require() with requireNamespace().   
+    pData<- methods, replace require() with requireNamespace().
+    \item cpgCollapse now works for GenomicRatioSets since it no longer attempts 
+    to summarize CN data when passed a GenomicRatioSet.
   }
 }
 

--- a/man/cpgCollapse.Rd
+++ b/man/cpgCollapse.Rd
@@ -22,7 +22,7 @@ cpgCollapse(object, what = c("Beta", "M"), maxGap = 500,
 }
 
 \arguments{
-  \item{object}{An object of class \code{[Genomic]MethylSet}.}
+  \item{object}{An object of class \code{[Genomic]MethylSet} or \code{[Genomic]RatioSet}.}
   \item{what}{Should operation be performed on the M-scale or
   Beta-scale?}
   \item{maxGap}{Maximum gap between CpGs in a cluster}


### PR DESCRIPTION
These changes allow cpgCollapse to process GenomicRatioSets in addition to MethyRatioSets. The previous code failed on GenomicRatioSets since it tried to extract copy number information (getCN) from the object. The new version checks to see it has a MethylRatioSet before trying to summarize CN info.