### PR TITLE
Error when both base and targets supplied to read.450k.exp

### DIFF
--- a/R/read.450k.R
+++ b/R/read.450k.R
@@ -126,7 +126,7 @@ read.450k.exp <- function(base = NULL, targets = NULL, extended = FALSE,
         if(! "Basename" %in% names(targets))
             stop("Need 'Basename' amongst the column names of 'targets'")
         if(!is.null(base)) {
-            files <- file.path(base, targets$Basename)
+            files <- file.path(base, basename(targets$Basename))
         } else {
             files <- targets$Basename
         }


### PR DESCRIPTION
When both targets and base are supplied, file.path should be constructed from the base name of targets$Basename instead of the full name.