### PR TITLE
Fixed funnorm for EPIC array

### DIFF
--- a/R/preprocessFunnorm.R
+++ b/R/preprocessFunnorm.R
@@ -184,7 +184,7 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
         ctrls <- ctrlsList[[index]]
         addr <- ctrls$Address
         names(addr) <- ctrls$ExtendedType
-        addr[exType]
+        na.omit(addr[exType])
     }
     
     greenControls <- extractedData$greenControls


### PR DESCRIPTION
Added na.omit() to .buildControlMatrix450k without the missing bisulfite conversion1  probe on the EPIC array