### PR TITLE
Incorporate Bayesian measurement error procedure into estimateCellCounts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: minfi
-Version: 1.29.5
+Version: 1.33.1
 Title: Analyze Illumina Infinium DNA methylation arrays
 Description: Tools to analyze & visualize Illumina Infinium methylation arrays.
 Authors@R: c(person(c("Kasper", "Daniel"), "Hansen", role = c("cre", "aut"),

--- a/R/estimateCellCounts.R
+++ b/R/estimateCellCounts.R
@@ -297,8 +297,7 @@ estimateCellCounts <- function(rgSet, compositeCellType = "Blood",
         sampleNames = c(colnames(rgSet), colnames(referenceRGset)),
         studyIndex = rep(
             x = c("user", "reference"),
-            times = c(ncol(rgSet), ncol(referenceRGset))),
-        stringsAsFactors = FALSE)
+            times = c(ncol(rgSet), ncol(referenceRGset))))
     referencePd <- colData(referenceRGset)
     combinedRGset <- combineArrays(
         object1 = rgSet,

--- a/R/estimateCellCounts.R
+++ b/R/estimateCellCounts.R
@@ -351,9 +351,27 @@ estimateCellCounts <- function(rgSet, compositeCellType = "Blood",
         stop("the sample/column names in the user set must not be in the ",
              "reference data ")
     }
+    bayesEst <- FALSE
+    bayesParams <- data.frame(compositeCellType = c("CordBlood"), inferCellType = c("Eos"), inferReference = c("Blood"), minDiff = c(-0.85), maxDiff = c(0.26)) #Can be modified when additional priors are estimated. 
     if (!all(cellTypes %in% referenceRGset$CellType)) {
-        stop(sprintf("all elements of argument 'cellTypes' needs to be part of the reference phenoData columns 'CellType' (containg the following elements: '%s')",
-                     paste(unique(referenceRGset$cellType), collapse = "', '")))
+        inferCellType <- cellTypes[!cellTypes%in%referenceRGset$CellType]
+        validrow <- which(bayesParams$inferCellType %in% inferCellType)
+        if (length(validrow) == 1){
+            if(bayesParams$compositeCellType[validrow] %in% compositeCellType){
+                bayesEst <- TRUE
+                bayesParams <- bayesParams[validrow,]
+                validrow <- match(compositeCellType, bayesParams$compositeCellType)
+               
+                inferCellType <- as.character(with(bayesParams, inferCellType[validrow]))
+                cellTypes <- cellTypes[!cellTypes %in% inferCellType]
+                inferReference <- as.character(with(bayesParams, inferReference[validrow]))
+                minDiff <- with(bayesParams, minDiff[validrow])
+                maxDiff <-  with(bayesParams, maxDiff[validrow])
+            }
+        } else{
+            stop(paste0("all elements of argument 'cellTypes' need to be part of the reference phenoData columns 'CellType' (containg the following elements: ",
+             paste(unique(referenceRGset$CellType), collapse = "', '"),") or have known priors to supply to Bayesian measurement error inference function."))
+        }
     }
     if (length(unique(cellTypes)) < 2) {
         stop("At least 2 cell types must be provided.")

--- a/R/estimateCellCounts.R
+++ b/R/estimateCellCounts.R
@@ -452,6 +452,19 @@ estimateCellCounts <- function(rgSet, compositeCellType = "Blood",
     counts <- projectCellType(getBeta(mSet)[rownames(coefs), ], coefs)
     rownames(counts) <- colnames(rgSet)
 
+    if (bayesEst == TRUE){
+        if (verbose) message("[estimateCellCounts] Estimating ",inferCellType," composition using Bayesian measurement error model.\n")
+            if (!("Gran" %in% cellTypes) && inferCellType == "Eos"){
+                    message("[estimateCellCounts] It is recommended for 'Gran' to be included in cellTypes argument for eosinophil estimation.\n")
+            } else {
+                    if (length(cellTypes) < 3){
+                        warning("[estimateCellCounts] At least 3 requested cell types recommended for Bayesian measurement error model.\n")
+                    }
+                        counts <- Bayes.estimate(rgSet, counts, referencePkg, compositeCellType, inferReference = inferReference,
+                            inferCellType = inferCellType, minDiff = minDiff, maxDiff = maxDiff, verbose = verbose)
+            }
+    }   
+    
     if (meanPlot) {
         smeans <- compData$sampleMeans
         smeans <- smeans[order(names(smeans))]

--- a/R/qc.R
+++ b/R/qc.R
@@ -68,7 +68,7 @@ controlStripPlot <- function(rgSet,
         ctl <- rbind(
             cbind(channel = "Red", ctlR),
             cbind(channel = "Green", ctlG))
-        if (any((ctl$value < xlim[1]) || (ctl$value > xlim[2]))) {
+        if (any((ctl$value < xlim[1]) | (ctl$value > xlim[2]))) {
             message("Warning: ", controlType, " probes outside plot range")
         }
         fig <- xyplot(

--- a/R/read.geo.R
+++ b/R/read.geo.R
@@ -60,7 +60,7 @@ makeGenomicRatioSetFromMatrix <- function(mat,rownames = NULL, pData = NULL,
     if (is.null(pData)) {
         pData <- DataFrame(X1 = seq_len(ncol(mat)), row.names = colnames(mat))
     }
-    if (class(pData) != "DataFrame") {
+    if (!is(pData, "DataFrame")) {
         stop(sprintf(
             "'pData' must be DataFrame or data.frame. It is a %s.",
             class(pData)))

--- a/man/estimateCellCounts.Rd
+++ b/man/estimateCellCounts.Rd
@@ -15,6 +15,7 @@ estimateCellCounts(rgSet, compositeCellType = "Blood",
                    referencePlatform = c("IlluminaHumanMethylation450k",
                                          "IlluminaHumanMethylationEPIC",
                                          "IlluminaHumanMethylation27k"),
+                   bayesMethod = TRUE,
                    returnAll = FALSE, meanPlot = FALSE, verbose = TRUE, \dots)
 }
 \arguments{
@@ -39,6 +40,7 @@ estimateCellCounts(rgSet, compositeCellType = "Blood",
   \item{referencePlatform}{The platform for the reference dataset; if
     the input \code{rgSet} belongs to another platform, it will be
     converted using \code{\link{convertArray}}.}
+  \item{bayesMethod}{Should the Bayesian measurement error inference method be used to estimate elements of cellTypes that are not included in the specified reference platform? See details.}
   \item{returnAll}{Should the composition table and the normalized user
     supplied data be return?}
   \item{verbose}{Should the function be verbose?}
@@ -66,6 +68,8 @@ via the \code{cellTypes} argument. For blood, these are "Bcell", "CD4T", "CD8T",
 For cord blood, these are "Bcell", "CD4T", "CD8T", "Gran", "Mono", "Neu", and "nRBC". For frontal
 cortex, these are "NeuN_neg" and "NeuN_pos". See documentation of individual reference packages for
 more details.
+
+When \code{bayesMethod} is TRUE, and elements of \code{cellTypes} are not in the specified reference data package, the function will attempt to use a Bayesian measurement error procedure to estimate the additional cell type. Currently, this feature only supports eosinophil estimation when \code{compositeCellType} is "CordBlood", but additional cell type - tissue combinations will be added in the future. See Jiang and Zhang et al. for additional details.
 
 The \code{meanPlot} should be used to check for large batch effects in the data,
 reducing the confidence placed in the composition estimates. This plot

--- a/man/estimateCellCounts.Rd
+++ b/man/estimateCellCounts.Rd
@@ -103,6 +103,11 @@ batch effects.
   \emph{DNA methylation of cord blood cell types: Applications for mixed cell birth studies.}
   Epigenetics (2016) 11:5.
   doi:\href{http://dx.doi.org/10.1080/15592294.2016.1161875}{10.1080/15592294.2016.1161875}.
+
+  Y Jiang, H Zhang, SV Andrews, H Arshad, S Ewart, JW Holloway, MD Fallin, KM Bakulski, and W Karmaus.
+  \emph{Estimation of Eosinophil Cells in Cord Blood with References Based on Blood in Adults via Bayesian Measurement Error Modeling.}
+  Bioinformatics (2019).
+  doi:\href{https://doi.org/10.1093/bioinformatics/btz839}{10.1093/bioinformatics/btz839}. 
 }
 
 \author{


### PR DESCRIPTION
New functionality to estimateCellCounts that will allow for eosinophil estimation in cord blood using the adult blood reference panel. Can be extended for additional cell types in the future. 