### PR TITLE
Update estimateCellCounts.R

### DIFF
--- a/R/estimateCellCounts.R
+++ b/R/estimateCellCounts.R
@@ -54,6 +54,7 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
     }
 
     trainingProbes <- unique(unlist(probeList))
+    trainingProbes <- trainingProbes[!is.na(trainingProbes)]
     p <- p[trainingProbes,]
 
     pMeans <- colMeans2(p)


### PR DESCRIPTION
This should fix an issue encountered when working from the cord blood reference RGsets (e.g. FlowSorted.CordBlood.450k, etc.). The former approach retains a single NA in `trainingProbes` if any were encountered in `probeList`, which will get passed to `p[trainingProbes,]` and throw an error. For details, see: https://support.bioconductor.org/p/9148370/