### PR TITLE
Compatibility with Illumina Mouse Array and EPIC Version 2

### DIFF
--- a/R/preprocessFunnorm.R
+++ b/R/preprocessFunnorm.R
@@ -209,12 +209,18 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
     index <- match("BISULFITE CONVERSION I", controlNames)
     if (array=="IlluminaHumanMethylation450k"){
         addr <- getCtrlsAddr(exType = sprintf("BS Conversion I%sC%s", c(" ", "-", "-"), 1:3), index = index)
+    } else if (array == "IlluminaMouseMethylation") {
+        ids <- paste0(rep(c(396, 140), each = 2), rep(c("U", "C"), each = 2)) # mouse BS1 ids
+        addr <- getCtrlsAddr(exType = sprintf("BS1-%s_MUS", ids), index = index)
     } else {
         addr <- getCtrlsAddr(exType = sprintf("BS Conversion I%sC%s", c("-", "-"), 1:2), index = index)
     }
     greenControls.current <- greenControls[[ index ]][addr,,drop=FALSE]
     if (array=="IlluminaHumanMethylation450k"){
         addr <- getCtrlsAddr(exType = sprintf("BS Conversion I-C%s", 4:6), index = index)
+    } else if (array == "IlluminaMouseMethylation"){
+        ids <- paste0(rep(c(409, 318, 317), each = 2), rep(c("U", "C"), each = 2)) # mouse BS1 ids
+        addr <- getCtrlsAddr(exType = sprintf("BS1-%s_MUS", ids), index = index)
     } else {
         addr <- getCtrlsAddr(exType = sprintf("BS Conversion I-C%s", 3:5), index = index)
     }
@@ -228,17 +234,33 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
 
     ## Staining
     index <- match("STAINING", controlNames)
-    addr <- getCtrlsAddr(exType = "Biotin (High)", index = index)
+    if (array == "IlluminaMouseMethylation"){
+        addr <- getCtrlsAddr(exType = "STN-Biotin-High", index = index)
+    } else {
+        addr <- getCtrlsAddr(exType = "Biotin (High)", index = index)
+    }
     stain.green <- t(greenControls[[ index ]][addr,,drop=FALSE])
-    addr <- getCtrlsAddr(exType = "DNP (High)", index = index)
+    if (array == "IlluminaMouseMethylation"){
+        addr <- getCtrlsAddr(exType = "STN-DNP-High", index = index)
+    } else {
+        addr <- getCtrlsAddr(exType = "DNP (High)", index = index)
+    }
     stain.red <- t(redControls[[ index ]][addr,, drop=FALSE ])
 
     ## Extension
     index <-    match("EXTENSION", controlNames)
-    addr <- getCtrlsAddr(exType = sprintf("Extension (%s)", c("A", "T")), index = index)
+    if (array == "IlluminaMouseMethylation"){
+        addr <- getCtrlsAddr(exType = sprintf("EXT-%s", c("A", "T")), index = index)
+    } else {
+        addr <- getCtrlsAddr(exType = sprintf("Extension (%s)", c("A", "T")), index = index)
+    }
     extension.red <- t(redControls[[index]][addr,,drop=FALSE])
     colnames(extension.red) <- paste0("extRed", 1:ncol(extension.red))
-    addr <- getCtrlsAddr(exType = sprintf("Extension (%s)", c("C", "G")), index = index)
+    if (array == "IlluminaMouseMethylation"){
+        addr <- getCtrlsAddr(exType = sprintf("EXT-%s", c("C", "G")), index = index)
+    }  else {
+        addr <- getCtrlsAddr(exType = sprintf("Extension (%s)", c("C", "G")), index = index)
+    }
     extension.green <- t(greenControls[[index]][addr,,drop=FALSE])
     colnames(extension.green) <- paste0("extGrn", 1:ncol(extension.green))
 
@@ -254,10 +276,18 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
 
     ## Non-polymorphic probes
     index <- match("NON-POLYMORPHIC", controlNames)
-    addr <- getCtrlsAddr(exType = sprintf("NP (%s)", c("A", "T")), index = index)
+    if (array == "IlluminaMouseMethylation"){
+        addr <- getCtrlsAddr(exType = sprintf("NPM-%s_MUS", c("A", "T")), index = index)
+    } else {
+        addr <- getCtrlsAddr(exType = sprintf("NP (%s)", c("A", "T")), index = index)
+    }
     nonpoly.red <- t(redControls[[index]][addr, ,drop=FALSE])
     colnames(nonpoly.red) <- paste0("nonpolyRed", 1:ncol(nonpoly.red))
-    addr <- getCtrlsAddr(exType = sprintf("NP (%s)", c("C", "G")), index = index)
+    if (array == "IlluminaMouseMethylation"){
+        addr <- getCtrlsAddr(exType = sprintf("NPM-%s_MUS", c("C", "G")), index = index)
+    } else {
+        addr <- getCtrlsAddr(exType = sprintf("NP (%s)", c("C", "G")), index = index)
+    }
     nonpoly.green <- t(greenControls[[index]][addr, ,drop=FALSE])
     colnames(nonpoly.green) <- paste0("nonpolyGrn", 1:ncol(nonpoly.green))
 
@@ -274,7 +304,12 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
 
     ## Specificity I
     index <- match("SPECIFICITY I", controlNames)
-    addr <- getCtrlsAddr(exType = sprintf("GT Mismatch %s (PM)", 1:3), index = index)
+    if(array == "IlluminaMouseMethylation"){
+        ids <- paste0(rep(c("PM", "MM"), 3), rep(c(1:3), each = 2))
+        addr <- getCtrlsAddr(exType = sprintf("SP1-%s_HSA", ids), index = index)
+    } else {
+        addr <- getCtrlsAddr(exType = sprintf("GT Mismatch %s (PM)", 1:3), index = index)
+    }
     greenControls.current <- greenControls[[index]][addr,,drop=FALSE]
     redControls.current <- redControls[[index]][addr,,drop=FALSE]
     spec1.green <- t(greenControls.current)
@@ -283,7 +318,12 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
         colMeans2(greenControls.current, na.rm = TRUE)
 
     index <- match("SPECIFICITY I", controlNames) # Added that line
-    addr <- getCtrlsAddr(exType = sprintf("GT Mismatch %s (PM)", 4:6), index = index)
+    if(array == "IlluminaMouseMethylation"){
+        ids <- paste0(rep(c("PM", "MM"), 3), rep(c(4:6), each = 2))
+        addr <- getCtrlsAddr(exType = sprintf("SP1-%s_HSA", ids), index = index)
+    } else {
+        addr <- getCtrlsAddr(exType = sprintf("GT Mismatch %s (PM)", 4:6), index = index)
+    }
     greenControls.current <- greenControls[[index]][addr,,drop=FALSE]
     redControls.current <- redControls[[index]][addr,,drop=FALSE]
     spec1.red <- t(redControls.current)

--- a/R/read.meth.R
+++ b/R/read.meth.R
@@ -5,11 +5,39 @@
         arrayAnnotation <- c(
             array = "IlluminaHumanMethylation450k",
             annotation = .default.450k.annotation)
+    } else if(nProbes >= 361000 && nProbes <= 362000){
+        arrayAnnotation <- c(
+            array = "IlluminaMouseMethylation",
+            annotation = "12.v1.mm10")
+
+        # Install package if needed
+        if(!require("devtools")) install.packages("devtools") # install devtools
+        if(!require("IlluminaMouseMethylationmanifest")) devtools::install_github("chiaraherzog/IlluminaMouseMethylationmanifest")
+        if(!require("IlluminaMouseMethylationanno.12.v1.mm10")) devtools::install_github("chiaraherzog/IlluminaMouseMethylationanno.12.v1.mm10")
+
+        # Load library
+        suppressPackageStartupMessages(library(IlluminaMouseMethylationmanifest))
+        suppressPackageStartupMessages(library(IlluminaMouseMethylationanno.12.v1.mm10))
+
     } else if (nProbes >= 1050000 && nProbes <= 1053000) {
         # NOTE: "Current EPIC scan type"
         arrayAnnotation <- c(
             array = "IlluminaHumanMethylationEPIC",
             annotation = .default.epic.annotation)
+    } else if(nProbes >= 1104000 && nProbes <= 1110000){
+        arrayAnnotation <- c(
+            array = "IlluminaHumanMethylationEPICv2",
+            annotation = "20a1.hg38")
+
+        # Install package if needed
+        if(!require("devtools")) install.packages("devtools") # install devtools
+        if(!require("IlluminaHumanMethylationEPICv2manifest")) devtools::install_github("jokergoo/IlluminaHumanMethylationEPICv2manifest")
+        if(!require("IlluminaHumanMethylationEPICv2anno.20a1.hg38")) devtools::install_github("jokergoo/IlluminaHumanMethylationEPICv2anno.20a1.hg38")
+
+        # Load library
+        suppressPackageStartupMessages(library(IlluminaHumanMethylationEPICv2manifest))
+        suppressPackageStartupMessages(library(IlluminaHumanMethylationEPICv2anno.20a1.hg38))
+
     } else if (nProbes >= 1032000 && nProbes <= 1033000) {
         # NOTE: "Old EPIC scan type"
         arrayAnnotation <- c(


### PR DESCRIPTION
I added minor modifications to
- guessArrayType (annotation for mouse and EPIC version 2 arrays):
if the respective manifest package is not installed, it is downloaded and installed from github
- preprocessFunnorm for compatibility with mouse array and annotation (Controls have slightly different names)
All changes are fully backward compatible.