### PR TITLE
Fixes selection of probes by type in preprocessNoob.

### DIFF
--- a/R/preprocessNoob.R
+++ b/R/preprocessNoob.R
@@ -384,10 +384,11 @@ preprocessNoob <- function(rgSet, offset = 15, dyeCorr = TRUE, verbose = FALSE,
     GreenOOB <- oob[["Grn"]]
     RedOOB <- oob[["Red"]]
     MSet <- preprocessRaw(rgSet)
-    probe.type <- getProbeType(MSet, withColor = TRUE)
-    Green_probes <- which(probe.type == "IGrn")
-    Red_probes <- which(probe.type == "IRed")
-    d2.probes <- which(probe.type == "II")
+    anno <- getAnnotation(MSet)
+    probe.type <- paste0(anno$Type, anno$Color)
+    Green_probes <- intersect(rownames(MSet), anno$Name[probe.type == "IGrn"])
+    Red_probes <- intersect(rownames(MSet), anno$Name[probe.type == "IRed"])
+    d2.probes <- intersect(rownames(MSet), anno$Name[probe.type == "II"])
     Meth <- getMeth(MSet)
     Unmeth <- getUnmeth(MSet)
 


### PR DESCRIPTION
This is a potential fix for https://github.com/hansenlab/minfi/issues/264. This hasn't been fully tested. Using the`match()` function might be slightly more efficient then doing hash lookups with the rownames, but I figured this was safer as it avoided any mis-mappings  downstream. 